### PR TITLE
discord does not support markdown links

### DIFF
--- a/discord.md
+++ b/discord.md
@@ -27,7 +27,7 @@ henkaku.org/伊藤穰一のポッドキャスト実験サーバーへようこ�
 2 - その後、 #collabland-join  に進み、アセットの確認/web3ウォレットの接続を @Collab.Land#6372 で行ってください。 @Collab.Land#6372 は、あなたの保有しているNFTを確認し、NFTに紐づくアクセス権や役割を与えるbotになります。まずは、我々のサーバーが保有NFTを確認することを許可してください。
 
 3 - # 👋 | introsで自己紹介をしてください。
-$HENKAKUトークンについて書かれたページ（ [https://henkaku.gitbook.io/community/henkaku-token-ja](https://henkaku.gitbook.io/community/henkaku-token-ja) ）を読んで、実験への参加に興味があるかどうかを @Admin に知らせてください。
+$HENKAKUトークンについて書かれたページ（ https://henkaku.gitbook.io/community/henkaku-token-ja ）を読んで、実験への参加に興味があるかどうかを @Admin に知らせてください。
 
 4 - チップ交換に参加するには、$HENKAKUと$MATICを入手し、 join チャンネルで!registerと入力して @coinvise-bot に登録する必要があります。
 
@@ -39,7 +39,7 @@ Welcome to the henkaku.org/Joi Ito's Podcast experimental server.
 
 3 - Introduce yourself on # 👋 | intros.
 
-4 - Read about $HENKAKU tokens [https://henkaku.gitbook.io/community/henkaku-token](https://henkaku.gitbook.io/community/henkaku-token) and let any @Admin know if you're interested in participating in the experiment.
+4 - Read about $HENKAKU tokens https://henkaku.gitbook.io/community/henkaku-token and let any @Admin know if you're interested in participating in the experiment.
 
 You will need to get some $HENKAKU, some $MATIC and !register in the join  channel with @coinvise-bot to exchange tips.
 
@@ -88,11 +88,10 @@ Agree to the rules by clicking the 👍 reaction at the bottom of this message a
 
 ### \# 🔗│links
 
-- $HENKAKU Token に付いて： [https://henkaku.gitbook.io/community/henkaku-token-ja](https://henkaku.gitbook.io/community/henkaku-token-ja)
-- About the $HENKAKU Token: [https://henkaku.gitbook.io/community/henkaku-token](https://henkaku.gitbook.io/community/henkaku-token)
-- Proposals and Polls on Snapshot / 提案やアンケートを作ったり投票する：[https://snapshot.org/#/henkaku.eth/](https://snapshot.org/#/henkaku.eth/)
+- $HENKAKU Token に付いて: https://henkaku.gitbook.io/community/henkaku-token-ja
+- About the $HENKAKU Token: https://henkaku.gitbook.io/community/henkaku-token
+- Proposals and Polls on Snapshot / 提案やアンケートを作ったり投票する: https://snapshot.org/#/henkaku.eth/
 
 Quests:
-- Start a Poll : [https://www.coinvise.co/quest/8393cc4c-e5e8-4849-adaa-6a17c2697cdc](https://www.coinvise.co/quest/8393cc4c-e5e8-4849-adaa-6a17c2697cdc)
-- Tip Someone: [https://www.coinvise.co/quest/a6a8af84-3f3d-4314-a494-fb9015d4bac3](https://www.coinvise.co/quest/a6a8af84-3f3d-4314-a494-fb9015d4bac3)
-
+- Start a Poll: https://www.coinvise.co/quest/8393cc4c-e5e8-4849-adaa-6a17c2697cdc
+- Tip Someone: https://www.coinvise.co/quest/a6a8af84-3f3d-4314-a494-fb9015d4bac3


### PR DESCRIPTION
- It is better to avoid markdown links in discord posts.
-  it is just redundantly doing [URL link](URL link)

***
This is a fix that conflicts with the following PR. We will prioritize the following PRs and make additional revisions to this one if necessary.

https://github.com/henkaku-center/henkaku-community/pull/18