### PR TITLE
Split langauges on the table of contents

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1,0 +1,9 @@
+# README
+
+## Discord Information
+* [Discord Assistants (Bots)](discord.md)
+
+## 公式ドキュメント
+* [変革会のトークン](henkaku-token-ja.md)
+* [FAQ](faq-ja.md)
+* [For Git Contributors](git-contribute-ja.md)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,8 @@
 
 ## Discord Information
 * [Discord Assistants (Bots)](discord.md)
+
 ## Official Documents in English
 * [The Henkaku Token](henkaku-token.md)
-* [FAQ (English)](faq.md)
-* [For Git Contributors (English)](git-contribute.md)
-
-## Official Documents in Japanese
-* [変革会のトークン](henkaku-token-ja.md)
-* [FAQ (日本語)](faq-ja.md)
-* [For Git Contributors (日本語)](git-contribute-ja.md)
+* [FAQ](faq.md)
+* [For Git Contributors](git-contribute.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,10 +1,11 @@
 # Table of contents
 
-* [README](README.md)
 * [Discord Assistants (Bots)](discord.md)
-* [The Henkaku Token](henkaku-token.md)
-* [FAQ (English)](faq.md)
-* [For Git Contributors (English)](git-contribute.md)
-* [FAQ (日本語)](faq-ja.md)
-* [For Git Contributors (日本語)](git-contribute-ja.md)
-* [変革会のトークン](henkaku-token-ja.md)
+* [Docs (English)](README.md)
+	* [The Henkaku Token](henkaku-token.md)
+	* [FAQ (English)](faq.md)
+	* [For Git Contributors (English)](git-contribute.md)
+* [ドキュメント (日本語)](README-ja.md)
+	* [FAQ (日本語)](faq-ja.md)
+	* [For Git Contributors (日本語)](git-contribute-ja.md)
+	* [変革会のトークン](henkaku-token-ja.md)


### PR DESCRIPTION
As it has been talked about a number of times, proposing to split the table of contents by language.

- The Discord page stays alone as it is not localised
- [The GitBook docs](https://snowdreams1006.github.io/gitbook-official/en/pages.html) suggest this nested list format for tables of contents -- I hope I am right on assuming one does not need to make subdirectories for the files if linked correctly